### PR TITLE
Fix Call Flow Status not displaying

### DIFF
--- a/app/call_flows/call_flows.php
+++ b/app/call_flows/call_flows.php
@@ -167,7 +167,7 @@
 				$tr_link = "href='call_flow_edit.php?id=".$row['call_flow_uuid']."'";
 			}
 			echo "<tr ".$tr_link.">\n";
-			echo "	<td valign='top' class='".$row_style[$c]."'>";
+			//echo "	<td valign='top' class='".$row_style[$c]."'>";
 			if ($row['call_flow_status'] != "false") {
 				echo $row['call_flow_label'];
 			}
@@ -177,6 +177,7 @@
 			echo 		"&nbsp;\n";
 			echo "	</td>\n";
 			//echo "	<td valign='top' class='".$row_style[$c]."'>".$row['call_flow_name']."&nbsp;</td>\n";
+			echo "  <td valign='top' class='".$row_style[$c]."'>".$row['call_flow_status']."&nbsp;</td>\n";
 			echo "	<td valign='top' class='".$row_style[$c]."'>".$row['call_flow_extension']."&nbsp;</td>\n";
 			echo "	<td valign='top' class='".$row_style[$c]."'>".$row['call_flow_feature_code']."&nbsp;</td>\n";
 			//echo "	<td valign='top' class='".$row_style[$c]."'>".$row['call_flow_context']."&nbsp;</td>\n";


### PR DESCRIPTION
If a call flow is true/false it displays as blank
this fix allows you to see the status from the main page and not just blank